### PR TITLE
Create a Polish localisation

### DIFF
--- a/locale/pl/locale.cfg
+++ b/locale/pl/locale.cfg
@@ -1,0 +1,40 @@
+[fluid-name]
+science-pack-1-fluid=Wiedza w płynie 1
+science-pack-2-fluid=Wiedza w płynie 2
+science-pack-3-fluid=Wiedza w płynie 3
+alien-science-pack-fluid=Wiedza kosmitów w płynie
+#production-science-pack-fluid=Wiedza produkcyjna w płynie
+#military-science-pack-fluid=Wiedza wojskowa w płynie
+high-tech-science-pack-fluid=Wiedza wysokich technologii w płynie
+
+#own list of [base game] science ingame:
+
+
+#Automation science= red science
+
+#green science
+logistic-science-pack-fluid=Wiedza logistyczna w płynie
+
+#blue science 
+chemical-science-pack-fluid=Wiedza chemiczna w płynie
+
+#black science = military science pack
+military-science-pack-fluid=Wiedza wojskowa w płynie
+
+#purple science = science pack
+production-science-pack-fluid=Wiedza produkcyjna w płynie
+
+# yellow science = utility science pack
+utility-science-pack-fluid=Wiedza użytkowa w płynie
+
+[entity-name]
+#more detailed fitting name that shows both purposes 
+science-pump=Rozlewnia Science Extractor Bottler
+sand-ore=Sand
+
+[item-name]
+glass=Szkło laboratoryjne
+sand=Piasek kwarcowy
+
+[autoplace-control-names]
+sand-ore=Piasek kwarcowy


### PR DESCRIPTION
I used longer names for sand and glass to expand their purpose. However, glass is not made of ordinary sand but special for the production of a given type of glass.

Glass is also different. Here we have laboratory glass for chemical flasks.

And finally:
`Science` - I used a Polish synonym for science: knowledge. Knowledge creates Science.